### PR TITLE
Cancel all observers when reset is called

### DIFF
--- a/render.js
+++ b/render.js
@@ -79,6 +79,9 @@ module.exports = function RactiveStateRouter(Ractive, ractiveOptions, options) {
 			reset: function reset(context, cb) {
 				const ractive = context.domApi
 				ractive.off()
+				if(ractive._observers && Array.isArray(ractive._observers)) {
+					ractive._observers.forEach(o => o.cancel())
+				}
 				wrapWackyPromise(ractive.reset(copyIfAppropriate(context.content)), cb)
 			},
 			destroy: function destroy(ractive, cb) {


### PR DESCRIPTION
Prior to this, duplicate observers would get subscribed if they navigated to the same state but with different params.